### PR TITLE
Cherry pick จาก 0.1.10-rc4

### DIFF
--- a/templates/canal.go
+++ b/templates/canal.go
@@ -388,6 +388,9 @@ spec:
             mountPath: /run
           - name: flannel-cfg
             mountPath: /etc/kube-flannel/
+          - name: xtables-lock
+            mountPath: /run/xtables.lock
+            readOnly: false
       volumes:
         # Used by calico/node.
         - name: lib-modules
@@ -413,6 +416,10 @@ spec:
         - name: flannel-cfg
           configMap:
             name: canal-config
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
 
 # Create all the CustomResourceDefinitions needed for
 # Calico policy-only mode.


### PR DESCRIPTION
Mounting xtables lock within canal pod

(cherry picked from commit 8e3bf48a9485faf3300cbdab58ac30ea63de0a2d)
Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>