### PR TITLE
ปรับรุ่น kubernetes เป็น v1.10.7 - cherry pick จาก v.1.9-ske

### DIFF
--- a/scripts/dist-ske
+++ b/scripts/dist-ske
@@ -24,7 +24,7 @@ mkdir dist/ske-${VERSION}
 
 
 ISTIO_VERSION=1.0.1
-KUBE_VERSION=v1.10.6
+KUBE_VERSION=v1.10.7
 
 cp bin/ske dist/ske-${VERSION}/ske
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultK8s = "v1.10.6-sut1-1"
+	DefaultK8s = "v1.10.7-ske1-2"
 )
 
 var (
@@ -19,7 +19,9 @@ var (
 	k8sVersionsCurrent = []string{
 		"v1.9.7-rancher2-2",
 		"v1.10.5-rancher1-2",
-		"v1.10.6-sut1-1",
+		"v1.10.6-ske1-1",
+		"v1.10.7-ske1-1",
+		"v1.10.7-ske1-2",
 		"v1.11.2-rancher1-2",
 	}
 
@@ -412,7 +414,7 @@ var (
 			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
 			MetricsServer:             m("gcr.io/google_containers/metrics-server-amd64:v0.2.1"),
 		},
-		"v1.10.6-sut1-1": {
+		"v1.10.6-ske1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.1.12"),
 			Kubernetes:                m("gcr.io/google-containers/hyperkube-amd64:v1.10.6"),
 			Alpine:                    m("rancher/rke-tools:v0.1.13"),
@@ -422,6 +424,58 @@ var (
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8"),
+			KubeDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0"),
+			Flannel:                   m("quay.io/coreos/flannel:v0.9.1"),
+			FlannelCNI:                m("quay.io/coreos/flannel-cni:v0.2.0"),
+			CalicoNode:                m("quay.io/calico/node:v3.1.1"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.1.1"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CanalNode:                 m("quay.io/calico/node:v3.1.1"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.1.1"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.9.1"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.1.3"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.1.3"),
+			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:0.16.2-rancher1"),
+			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
+			MetricsServer:             m("gcr.io/google_containers/metrics-server-amd64:v0.2.1"),
+		},
+		"v1.10.7-ske1-1": {
+			Etcd:                      m("quay.io/coreos/etcd:v3.1.12"),
+			Kubernetes:                m("gcr.io/google-containers/hyperkube-amd64:v1.10.7"),
+			Alpine:                    m("rancher/rke-tools:v0.1.13"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.13"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.13"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.13"),
+			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8"),
+			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8"),
+			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8"),
+			KubeDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0"),
+			Flannel:                   m("quay.io/coreos/flannel:v0.9.1"),
+			FlannelCNI:                m("quay.io/coreos/flannel-cni:v0.2.0"),
+			CalicoNode:                m("quay.io/calico/node:v3.1.1"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.1.1"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CanalNode:                 m("quay.io/calico/node:v3.1.1"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.1.1"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.9.1"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.1.3"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.1.3"),
+			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:0.16.2-rancher1"),
+			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
+			MetricsServer:             m("gcr.io/google_containers/metrics-server-amd64:v0.2.1"),
+		},
+		"v1.10.7-ske1-2": {
+			Etcd:                      m("quay.io/coreos/etcd:v3.1.12"),
+			Kubernetes:                m("gcr.io/ske-release/hyperkube-amd64:v1.10.7-ske.0"),
+			Alpine:                    m("rancher/rke-tools:v0.1.13"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.13"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.13"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.13"),
+			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.10"),
+			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.10"),
+			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10"),
 			KubeDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0"),
 			Flannel:                   m("quay.io/coreos/flannel:v0.9.1"),
 			FlannelCNI:                m("quay.io/coreos/flannel-cni:v0.2.0"),


### PR DESCRIPTION
update kubernetes to v1.10.7

* add v1.10.7 to the current list
* update kubectl download script to 1.10.7
* update image to kube ske.0 build
* update kubedns to 1.14.10
(cherry picked from commit 3756f2093fb6b11c6f51de80f760a2d4c59cd0dc)

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>

Conflicts:
	vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go